### PR TITLE
Fix issues with firmware updates

### DIFF
--- a/scripts/add_dfu_header.py
+++ b/scripts/add_dfu_header.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: LGPL-2.1+
+
+import struct
+import zlib
+import argparse
+
+
+def main(bin_fn, dfu_fn, pad, vid, pid, rev):
+
+    # read binary file
+    with open(bin_fn, 'rb') as f:
+        blob = f.read()
+
+    # pad blob to a specific size
+    if pad:
+        while len(blob) < int(pad, 16):
+            blob += b'\0'
+
+    # create DFU footer with checksum
+    blob += struct.pack(
+        '<HHHH3sB',
+        int(rev, 16),  # version
+        int(pid, 16),  # PID
+        int(vid, 16),  # VID
+        0x0100,  # DFU version
+        b'UFD',  # signature
+        0x10,
+    )  # hdrlen
+    crc32 = zlib.crc32(blob) ^ 0xFFFFFFFF
+    blob += struct.pack('<L', crc32)
+
+    # write binary file
+    with open(dfu_fn, 'wb') as f:
+        f.write(blob)
+
+
+if __name__ == "__main__":
+
+    # parse args
+    parser = argparse.ArgumentParser(description='Add DFU footer on firmware')
+    parser.add_argument('--bin', help='Path to the .bin file', required=True)
+    parser.add_argument('--dfu', help='Output DFU file path', required=True)
+    parser.add_argument(
+        '--pad', help='Pad to a specific size, e.g. 0x4000', default=None
+    )
+    parser.add_argument('--vid', help='Vendor ID, e.g. 0x273f', required=True)
+    parser.add_argument('--pid', help='Product ID, e.g. 0x1002', required=True)
+    parser.add_argument('--rev', help='Revision, e.g. 0x1000', required=True)
+    args = parser.parse_args()
+    main(args.bin, args.dfu, args.pad, args.vid, args.pid, args.rev)

--- a/scripts/lvfs.sh
+++ b/scripts/lvfs.sh
@@ -47,16 +47,17 @@ rm -rf "${BUILD}"
 mkdir -pv "${BUILD}"
 
 make "build/atmega32u4/main.bin"
-dfu-tool convert dfu "build/atmega32u4/main.bin" "${BUILD}/firmware.dfu"
-dfu-tool set-vendor "${BUILD}/firmware.dfu" "0x${RUNTIME_VID}"
-dfu-tool set-product "${BUILD}/firmware.dfu" "0x${RUNTIME_PID}"
-dfu-tool set-release "${BUILD}/firmware.dfu" "0x${RUNTIME_REV}"
-dfu-tool dump "${BUILD}/firmware.dfu"
+./scripts/add_dfu_header.py \
+    --bin "build/atmega32u4/main.bin" \
+    --dfu "${BUILD}/firmware.dfu" \
+    --vid "${RUNTIME_VID}" \
+    --pid "${RUNTIME_PID}" \
+    --rev "${RUNTIME_REV}"
 
 echo "writing '${BUILD}/firmware.metainfo.xml'"
 cat > "${BUILD}/firmware.metainfo.xml" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2019 System76 <info@system76.com> -->
+<!-- Copyright 2021 System76 <info@system76.com> -->
 <component type="firmware">
   <id>com.system76.ThelioIo.firmware</id>
   <name>Thelio Io</name>
@@ -95,6 +96,7 @@ cat > "${BUILD}/firmware.metainfo.xml" <<EOF
   </keywords>
   <custom>
     <value key="LVFS::UpdateProtocol">org.usb.dfu</value>
+    <value key="LVFS::VersionFormat">triplet</value>
   </custom>
 </component>
 EOF

--- a/src/cmd/thelio.c
+++ b/src/cmd/thelio.c
@@ -247,7 +247,7 @@ void thelio_init(struct Thelio * thelio) {
     pin_set_dir(thelio->cpufanmux, 1);
     pin_set(thelio->cpufanmux, 0);
 
-    // Get motherboard LED polarity
+    // Get motherboard LED polarity (system is off at this point, except after firmware update)
     thelio->motherled_off = pin_get(thelio->motherled);
 
     // Initialize devices
@@ -317,6 +317,9 @@ void thelio_command(struct Thelio * thelio, uint64_t time, char * command, FILE 
             error = 0;
         } else if (strncmp(command + 2, "RSET", 4) == 0) {
             thelio->suspend_state = 0;
+
+            // Update motherboard LED polarity (system will be on at this point)
+            thelio->motherled_off = !pin_get(thelio->motherled);
 
             error = 0;
         } else if (strncmp(command + 2, "BOOT", 4) == 0) {


### PR DESCRIPTION
Rebase and tag 1.0.4 when approved. Upload new firmware to LVFS
- Power button polarity will be stable through firmware updates (hopefully)
- LVFS firmware can be generated again
```
echo 1 | sudo tee /sys/bus/usb/drivers/system76-io/*.1/bootloader
make dfu
```